### PR TITLE
Revert "Disable backstace deps"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,8 +145,6 @@ include(folly-deps) # Find the required packages
 include(FollyConfigChecks)
 # Disable unwind
 set(FOLLY_HAVE_LIBUNWIND OFF)
-# Disable backstrace
-set(FOLLY_HAVE_BACKTRACE OFF)
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/CMake/folly-config.h.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/folly/folly-config.h


### PR DESCRIPTION
Reverts milvus-io/folly#17

Not fully tested on macOS, revert it.