### PR TITLE
fix folly runpath

### DIFF
--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -96,7 +96,7 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py build --src-dir=. folly  --project-install-prefix folly:/usr/local
     - name: Copy artifacts
       run: python3 build/fbcode_builder/getdeps.py fixup-dyn-deps --strip --src-dir=. folly _artifacts/linux  --project-install-prefix folly:/usr/local --final-install-prefix /usr/local
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: folly
         path: _artifacts

--- a/.github/workflows/getdeps_mac.yml
+++ b/.github/workflows/getdeps_mac.yml
@@ -91,7 +91,7 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py build --src-dir=. folly  --project-install-prefix folly:/usr/local
     - name: Copy artifacts
       run: python3 build/fbcode_builder/getdeps.py fixup-dyn-deps --src-dir=. folly _artifacts/mac  --project-install-prefix folly:/usr/local --final-install-prefix /usr/local
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: folly
         path: _artifacts

--- a/.github/workflows/getdeps_windows.yml
+++ b/.github/workflows/getdeps_windows.yml
@@ -90,7 +90,7 @@ jobs:
       run: python build/fbcode_builder/getdeps.py build --src-dir=. folly 
     - name: Copy artifacts
       run: python build/fbcode_builder/getdeps.py fixup-dyn-deps --src-dir=. folly _artifacts/windows  --final-install-prefix /usr/local
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: folly
         path: _artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ folly/m4/lt~obsolete.m4
 folly/generate_fingerprint_tables
 folly/FingerprintTables.cpp
 _build
+build

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,5 @@
 from conan.tools.microsoft import is_msvc, msvc_runtime_flag
+
 from conan.tools.build import can_run, check_min_cppstd
 from conan.tools.scm import Version
 from conan.tools import files
@@ -31,6 +32,7 @@ class FollyConan(ConanFile):
         "fPIC": True,
         "use_sse4_2": True,
         "fmt:header_only": True,
+        "glog:with_gflags": True
     }
     exports_sources = (
         "folly/*",
@@ -225,6 +227,12 @@ class FollyConan(ConanFile):
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         # Honor BUILD_SHARED_LIBS from conan_toolchain (see https://github.com/conan-io/conan/issues/11840)
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
+        
+        # Set RPATH for proper library linking
+        if self.settings.os != "Windows":
+            tc.variables["CMAKE_INSTALL_RPATH_USE_LINK_PATH"] = "TRUE"
+            tc.variables["CMAKE_BUILD_WITH_INSTALL_RPATH"] = "TRUE"
+            tc.variables["CMAKE_INSTALL_RPATH"] = "${CMAKE_INSTALL_PREFIX}/lib"
 
         cxx_std_flag = tools.cppstd_flag(self.settings)
         cxx_std_value = (


### PR DESCRIPTION
fix "libfolly_exception_tracer_base.so.0.58.0-dev: cannot open shared object file: No such file or director" when LD_LIBRARY_PATH not set